### PR TITLE
Using dark theme by default

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -66,16 +66,6 @@ def antmicro_html(
         ],
         "palette": [
             {
-                "media": "(prefers-color-scheme: light)",
-                "scheme": "default",
-                "primary": "teal",
-                "accent": "deep-orange",
-                "toggle": {
-                    "icon": "material/weather-night",
-                    "name": "Switch to dark mode",
-                },
-            },
-            {
                 "media": "(prefers-color-scheme: dark)",
                 "scheme": "slate",
                 "primary": "teal",
@@ -83,6 +73,16 @@ def antmicro_html(
                 "toggle": {
                     "icon": "material/weather-sunny",
                     "name": "Switch to light mode",
+                },
+            },
+            {
+                "media": "(prefers-color-scheme: light)",
+                "scheme": "default",
+                "primary": "teal",
+                "accent": "deep-orange",
+                "toggle": {
+                    "icon": "material/weather-night",
+                    "name": "Switch to dark mode",
                 },
             },
         ],

--- a/defaults.py
+++ b/defaults.py
@@ -66,7 +66,6 @@ def antmicro_html(
         ],
         "palette": [
             {
-                "media": "(prefers-color-scheme: dark)",
                 "scheme": "slate",
                 "primary": "teal",
                 "accent": "deep-orange",
@@ -76,7 +75,6 @@ def antmicro_html(
                 },
             },
             {
-                "media": "(prefers-color-scheme: light)",
                 "scheme": "default",
                 "primary": "teal",
                 "accent": "deep-orange",


### PR DESCRIPTION
This PR:

* Enables using dark theme for documentation by default
* Disables obtaining system's or browser's preference of theme