### PR TITLE
Added dependencies of the module to setup.py script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
-from typing import List
-
 from setuptools import setup as setuptools_setup
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,13 @@ setuptools_setup(
             "logo/*.svg",
         ],
     },
+    install_requires=[
+        'myst-parser',
+        'sphinx',
+        'sphinxcontrib-mermaid',
+        'sphinx-immaterial @ https://github.com/antmicro/sphinx-immaterial/releases/download/tip/sphinx_immaterial-0.0.post1.tip-py3-none-any.whl',  # noqa: E501
+        'sphinx_tabs',
+    ],
     classifiers=[],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
This PR adds dependencies for `antmicro-sphinx-utils` module to the list of requirements in `setup.py` file.